### PR TITLE
Fix error when using moduleResolution to Node16 or NodeNext

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,10 @@
   "name": "dindist",
   "version": "0.0.0-dripip",
   "description": "Fixed version of endent",
+  "type": "module",
   "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts"
   "files": [
     "dist"
   ],


### PR DESCRIPTION
Hello,

With `moduleResolution` set to `NodeNext` or `Node16` we have a lot of errors with TypeScript 4.8.x:

```
error TS2349: This expression is not callable.
  Type 'typeof import("/Users/20011083/Dev/nexus-prisma/node_modules/dindist/dist/index")' has no call signatures.
```

I got this issue by trying to upgrade `nexus-prisma` plugin to use `NodeNext` and to full managed esm module (https://github.com/graphql-nexus/nexus-prisma/issues/200)

Once I'll finish I'll create a PR on nexus-primas plugin repository, but that PR stuck me to continue

see https://github.com/vitejs/vite/issues/10481

Thanks !
